### PR TITLE
Перемотка елементов Body на первый элемент.

### DIFF
--- a/src/ResponseTransformer/ArrayResponseTransformer.php
+++ b/src/ResponseTransformer/ArrayResponseTransformer.php
@@ -17,6 +17,7 @@ class ArrayResponseTransformer implements ResponseTransformerInterface
      */
     public function transform(ResponseInterface $response)
     {
+        $response->getBody()->rewind();
         return json_decode($response->getBody()->getContents(), true);
     }
 

--- a/src/ResponseTransformer/StdObjectResponseTransformer.php
+++ b/src/ResponseTransformer/StdObjectResponseTransformer.php
@@ -17,6 +17,7 @@ class StdObjectResponseTransformer implements ResponseTransformerInterface
      */
     public function transform(ResponseInterface $response)
     {
+        $response->getBody()->rewind();
         return json_decode($response->getBody()->getContents());
     }
 


### PR DESCRIPTION
Если в Guzzle добавить логирование запросов с дебагом, логгер выбирает респонс `$response->getBody()->getContents()`. Перемещается указатель на след. запись в Body. И след запрос `$response->getBody()->getContents()` ничего не вернет. Решение либо делать перемотку либо получать весь контент как строку `(string)$response->getBody()`